### PR TITLE
Various minor usability changes

### DIFF
--- a/polysight-core-client/pom.xml
+++ b/polysight-core-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.richardinnocent.polysight</groupId>
   <artifactId>polysight-core-client</artifactId>
-  <version>0.0.3-ALPHA</version>
+  <version>0.0.4-ALPHA</version>
 
   <name>polysight-core-client</name>
   <description>A common library for Polysight client implementations to use.</description>

--- a/polysight-core-client/src/main/java/org/richardinnocent/polysight/core/client/request/RestTemplateServiceRequest.java
+++ b/polysight-core-client/src/main/java/org/richardinnocent/polysight/core/client/request/RestTemplateServiceRequest.java
@@ -1,5 +1,6 @@
 package org.richardinnocent.polysight.core.client.request;
 
+import java.util.Objects;
 import org.richardinnocent.polysight.core.client.service.PolysightService;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,16 @@ public abstract class RestTemplateServiceRequest<S extends PolysightService, R>
 
   private final S service;
   private final RestTemplate template;
+
+  /**
+   * Creates a new {@link PolysightService} that uses Spring's {@link RestTemplate} to execute
+   * requests.
+   * @param service The service to execute the request against.
+   */
+  @SuppressWarnings("unused")
+  public RestTemplateServiceRequest(S service) {
+    this(service, new RestTemplateBuilder());
+  }
 
   /**
    * Creates a new {@link PolysightService} that uses Spring's {@link RestTemplate} to execute
@@ -51,4 +62,21 @@ public abstract class RestTemplateServiceRequest<S extends PolysightService, R>
   protected abstract ResponseEntity<R> executeInternal(S service, RestTemplate template)
       throws RestClientException;
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RestTemplateServiceRequest)) {
+      return false;
+    }
+    RestTemplateServiceRequest<?, ?> that = (RestTemplateServiceRequest<?, ?>) o;
+    return Objects.equals(service, that.service) &&
+        Objects.equals(template, that.template);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(service, template);
+  }
 }

--- a/polysight-core-client/src/main/java/org/richardinnocent/polysight/core/client/service/AbstractPolysightService.java
+++ b/polysight-core-client/src/main/java/org/richardinnocent/polysight/core/client/service/AbstractPolysightService.java
@@ -35,4 +35,21 @@ public abstract class AbstractPolysightService implements PolysightService {
     return baseUri + "/api/" + version.getUriForm();
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AbstractPolysightService)) {
+      return false;
+    }
+    AbstractPolysightService that = (AbstractPolysightService) o;
+    return Objects.equals(baseUri, that.baseUri) &&
+        Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(baseUri, version);
+  }
 }

--- a/polysight-core-client/src/main/java/org/richardinnocent/polysight/core/client/service/PolysightServiceConfiguration.java
+++ b/polysight-core-client/src/main/java/org/richardinnocent/polysight/core/client/service/PolysightServiceConfiguration.java
@@ -2,6 +2,9 @@ package org.richardinnocent.polysight.core.client.service;
 
 import java.util.Objects;
 
+/**
+ * Defines the configuration for a server, specifying how to communicate with it.
+ */
 public class PolysightServiceConfiguration {
 
   private final String baseUri;

--- a/polysight-core-client/src/test/java/org/richardinnocent/polysight/core/client/request/RestTemplateServiceRequestTest.java
+++ b/polysight-core-client/src/test/java/org/richardinnocent/polysight/core/client/request/RestTemplateServiceRequestTest.java
@@ -3,6 +3,8 @@ package org.richardinnocent.polysight.core.client.request;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -20,6 +22,13 @@ public class RestTemplateServiceRequestTest {
   @Before
   public void setUpBuilder() {
     when(templateBuilder.build()).thenReturn(template);
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    EqualsVerifier.forClass(RestTemplateServiceRequest.class)
+                  .suppress(Warning.STRICT_INHERITANCE)
+                  .verify();
   }
 
   @Test

--- a/polysight-core-client/src/test/java/org/richardinnocent/polysight/core/client/service/AbstractPolysightServiceTest.java
+++ b/polysight-core-client/src/test/java/org/richardinnocent/polysight/core/client/service/AbstractPolysightServiceTest.java
@@ -4,11 +4,20 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
 
 public class AbstractPolysightServiceTest {
+
+  @Test
+  public void testEqualsAndHashCode() {
+    EqualsVerifier.forClass(AbstractPolysightService.class)
+                  .suppress(Warning.STRICT_INHERITANCE)
+                  .verify();
+  }
 
   @Test
   public void testFieldsAreSetCorrectlyFromConstructor() {

--- a/polysight-core-common/pom.xml
+++ b/polysight-core-common/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.richardinnocent.polysight</groupId>
   <artifactId>polysight-core-common</artifactId>
-  <version>0.0.3-ALPHA</version>
+  <version>0.0.4-ALPHA</version>
   <packaging>jar</packaging>
 
   <name>polysight-core-common</name>

--- a/polysight-core-common/src/main/java/org/richardinnocent/polysight/core/common/mapper/ApiObjectMapper.java
+++ b/polysight-core-common/src/main/java/org/richardinnocent/polysight/core/common/mapper/ApiObjectMapper.java
@@ -1,5 +1,6 @@
 package org.richardinnocent.polysight.core.common.mapper;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.richardinnocent.polysight.core.common.mapper.modules.LocalDateModule;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,6 +16,7 @@ public class ApiObjectMapper extends ObjectMapper {
    * requests/responses, registering the appropriate modules.
    */
   public ApiObjectMapper() {
+    setSerializationInclusion(Include.NON_NULL);
     registerModule(new JodaModule());
     registerModule(new LocalDateModule());
   }

--- a/polysight-core-common/src/test/java/org/richardinnocent/polysight/core/common/mapper/ApiObjectMapperTest.java
+++ b/polysight-core-common/src/test/java/org/richardinnocent/polysight/core/common/mapper/ApiObjectMapperTest.java
@@ -28,4 +28,23 @@ public class ApiObjectMapperTest {
     );
   }
 
+  @Test
+  public void testNullValuesAreNotIncludedInTheSerialisation() throws JsonProcessingException {
+    @SuppressWarnings("unused")
+    class Data {
+      private final String populatedValue = "populated";
+      private final String emptyValue = null;
+
+      public String getPopulatedValue() {
+        return populatedValue;
+      }
+
+      public String getEmptyValue() {
+        return emptyValue;
+      }
+    }
+
+    assertEquals("{\"populatedValue\":\"populated\"}", MAPPER.writeValueAsString(new Data()));
+  }
+
 }


### PR DESCRIPTION
- Allowed `RestTemplateServiceRequest`s to be created without a `RestTemplate` for ease of use
- Stopped the `ApiObjectMapper` from serialising `null` values